### PR TITLE
fix(opam): use correct variable for ocamlformat

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -19,5 +19,6 @@
  (depends
   (ocaml (>= 4.08.0))
   (dune (>= 2.8.0))
+  (dune-configurator (>= 2.8.0))
   (ocamlfind :build)
   (ocamlformat :with-dev-setup)))

--- a/dune-project
+++ b/dune-project
@@ -4,8 +4,8 @@
 (name mysql8)
 
 (license LGPL-2.1)
-(maintainers "Zach Baylin <zach@skolem.tech>")
-(authors "Zach Baylin <zach@skolem.tech>")
+(maintainers "Zach Baylin <zach.baylin@skolem.com>")
+(authors "Zach Baylin <zach.baylin@skolem.com>")
 
 (source (github skolemlabs/mysql8))
 

--- a/dune-project
+++ b/dune-project
@@ -20,4 +20,4 @@
   (ocaml (>= 4.08.0))
   (dune (>= 2.8.0))
   (ocamlfind :build)
-  (ocamlformat :dev)))
+  (ocamlformat :with-dev-setup)))

--- a/mysql8.opam
+++ b/mysql8.opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8" & >= "2.8.0"}
   "ocamlfind" {build}
-  "ocamlformat" {dev}
+  "ocamlformat" {with-dev-setup}
   "odoc" {with-doc}
 ]
 build: [

--- a/mysql8.opam
+++ b/mysql8.opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/skolemlabs/mysql8/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8" & >= "2.8.0"}
+  "dune-configurator" {>= "2.8.0"}
   "ocamlfind" {build}
   "ocamlformat" {with-dev-setup}
   "odoc" {with-doc}


### PR DESCRIPTION
Before this was `dev`, but the correct term is `with-dev-setup`.

Source: https://opam.ocaml.org/doc/Manual.html#Scopes